### PR TITLE
Fix paths to assets of published version

### DIFF
--- a/scripts/render-index.js
+++ b/scripts/render-index.js
@@ -1,8 +1,9 @@
 const pug = require('pug');
 const path = require('path');
 
+const BASE_PATH = process.env.BASE_PATH || '';
 const PATH_PREFIX = 'https://github.com/funbox/api-blueprint-tutorial/tree/master/examples';
-const EXAMPLE_PREFIX = process.env.BASE_PATH || '';
+const EXAMPLE_PREFIX = BASE_PATH;
 
 const baseDir = path.resolve(__dirname, '../');
 const indexFile = path.join(baseDir, 'src/index.pug');
@@ -14,7 +15,7 @@ function renderIndexFile(examples) {
     source: `${PATH_PREFIX}/${exmp}`,
   }));
 
-  return pug.renderFile(indexFile, { examples: extendedExamples });
+  return pug.renderFile(indexFile, { examples: extendedExamples, basePath: BASE_PATH });
 }
 
 module.exports = renderIndexFile;

--- a/src/index.pug
+++ b/src/index.pug
@@ -1,16 +1,17 @@
 - const examples = locals.examples;
+- const basePath = locals.basePath;
 
 doctype html
 html(lang='ru')
   head
     meta(charset='utf-8')
     meta(name='viewport', content="initial-scale=1, width=device-width")
-    link(rel="apple-touch-icon", sizes="180x180", href="/apple-touch-icon.png" )
-    link(rel="shortcut icon", href="/favicon.ico")
-    link(rel="icon", type="image/png", href="/favicon-32x32.png", sizes="32x32")
-    link(rel="icon", type="image/png", href="/favicon-16x16.png", sizes="16x16")
-    link(rel="mask-icon", href="/safari-pinned-tab.svg", color="#5bbad5")
-    link(rel="stylesheet" href="/app.css")
+    link(rel="apple-touch-icon", sizes="180x180", href=`${basePath}/apple-touch-icon.png` )
+    link(rel="shortcut icon", href=`${basePath}/favicon.ico`)
+    link(rel="icon", type="image/png", href=`${basePath}/favicon-32x32.png`, sizes="32x32")
+    link(rel="icon", type="image/png", href=`${basePath}/favicon-16x16.png`, sizes="16x16")
+    link(rel="mask-icon", href=`${basePath}/safari-pinned-tab.svg`, color="#5bbad5")
+    link(rel="stylesheet" href=`${basePath}/app.css`)
     title APIB Tutorial
   body
     h1 Examples of API Blueprint sections


### PR DESCRIPTION
I've been wondering why we don't have any styles on [published version](https://funbox.github.io/api-blueprint-tutorial/). But we do have styles, and they're missing because I forgot to apply basePath to static assets.